### PR TITLE
Feature calendar most played

### DIFF
--- a/YearInReview/Infrastructure/UserControls/PlaytimeCalendar.xaml.cs
+++ b/YearInReview/Infrastructure/UserControls/PlaytimeCalendar.xaml.cs
@@ -107,10 +107,14 @@ namespace YearInReview.Infrastructure.UserControls
 			grid.Children.Add(header);
 		}
 		
+		/// <summary>
+		/// Calculate the most played game in the month and adds it to the second row of the grid.
+		/// As discussed in <see href="https://github.com/SparrowBrain/Playnite.YearInReview/issues/1">Issue #1</see>,
+		/// the calculation is done inside this UI logic, to avoid redundancy in the aggregation object.
+		/// </summary>
 		private static void AddMonthMostPlayedGame(IReadOnlyCollection<CalendarDayViewModel> monthDays, Grid grid)
 		{
 			// get list of games played in the month, ordered by total time played
-			// TODO this is probably not the best point to calculate this, maybe it should be done in the PlaytimeCalendarAggregator
 			var mostPlayedList = monthDays
 				.SelectMany(a => a.Games)
 				.GroupBy(a => a.Id)
@@ -124,13 +128,15 @@ namespace YearInReview.Infrastructure.UserControls
 			var mostPlayed = mostPlayedList.FirstOrDefault();
 			if (mostPlayed == null)
 			{
-				return;
+				return; // display nothing if there are no games played in the month
 			}
 			
-			// format the most played game time
-			string mostPlayedGameTime = ReadableTimeFormatter.FormatTime(mostPlayed.TotalTimePlayed);
-			string gameTimeText = $"{mostPlayed.Game.Name} ({mostPlayedGameTime})";
-			string mostPlayedText = string.Format(ResourceProvider.GetString("LOC_YearInReview_Report1970_PlaytimeCalendarMostPlayedGame"), gameTimeText);
+			// format the most played game with its total time played
+			string mostPlayedText = string.Format(
+				ResourceProvider.GetString("LOC_YearInReview_Report1970_PlaytimeCalendarMostPlayedGame"), 
+				mostPlayed.Game.Name,
+				ReadableTimeFormatter.FormatTime(mostPlayed.TotalTimePlayed)
+				);
 			
 			// add the most played game text to the grid
 			var mostPlayedGame = new TextBlock

--- a/YearInReview/Infrastructure/UserControls/PlaytimeCalendar.xaml.cs
+++ b/YearInReview/Infrastructure/UserControls/PlaytimeCalendar.xaml.cs
@@ -132,7 +132,7 @@ namespace YearInReview.Infrastructure.UserControls
 			}
 			
 			// format the most played game with its total time played
-			string mostPlayedText = string.Format(
+			var mostPlayedText = string.Format(
 				ResourceProvider.GetString("LOC_YearInReview_Report1970_PlaytimeCalendarMostPlayedGame"), 
 				mostPlayed.Game.Name,
 				ReadableTimeFormatter.FormatTime(mostPlayed.TotalTimePlayed)

--- a/YearInReview/Localization/en_US.xaml
+++ b/YearInReview/Localization/en_US.xaml
@@ -9,7 +9,7 @@
     <sys:String x:Key="LOC_YearInReview_Report1970_FriendsLeaderboardHeader">Let's see how you rank amongst your friends regarding playtime</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_MostPlayedGameMessage">It looks like you could not get enough of {0}. You've spent {1} playing it.</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_PlaytimeCalendarHeader">Here's how your playtime looked over the year</sys:String>
-    <sys:String x:Key="LOC_YearInReview_Report1970_PlaytimeCalendarMostPlayedGame">Most played game: {0}</sys:String>
+    <sys:String x:Key="LOC_YearInReview_Report1970_PlaytimeCalendarMostPlayedGame">Most played game: {0} ({1})</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_SingleSourceText">This year is all about {0}. You haven't played on any other libraries.</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_TopGamesHeader">And here's a look at your overall top {0}</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_TopSourcesHeader">Let's see which library was your favourite this year</sys:String>

--- a/YearInReview/Localization/en_US.xaml
+++ b/YearInReview/Localization/en_US.xaml
@@ -9,6 +9,7 @@
     <sys:String x:Key="LOC_YearInReview_Report1970_FriendsLeaderboardHeader">Let's see how you rank amongst your friends regarding playtime</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_MostPlayedGameMessage">It looks like you could not get enough of {0}. You've spent {1} playing it.</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_PlaytimeCalendarHeader">Here's how your playtime looked over the year</sys:String>
+    <sys:String x:Key="LOC_YearInReview_Report1970_PlaytimeCalendarMostPlayedGame">Most played game: {0}</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_SingleSourceText">This year is all about {0}. You haven't played on any other libraries.</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_TopGamesHeader">And here's a look at your overall top {0}</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_TopSourcesHeader">Let's see which library was your favourite this year</sys:String>


### PR DESCRIPTION
Implements the feature to display the most played game and its total play time for each month in the calendar view according to feature request in #1

As disscussed in the issue, the calculation of the most played game is done in the calendar UI class and not in the aggregator, due to possible redundancy when serializing the aggrgator class.