### PR TITLE
Feature added games report

### DIFF
--- a/YearInReview.UnitTests/Model/Reports/1970/Composer1970Tests.cs
+++ b/YearInReview.UnitTests/Model/Reports/1970/Composer1970Tests.cs
@@ -134,5 +134,25 @@ namespace YearInReview.UnitTests.Model.Reports._1970
 			// Assert
 			Assert.Equal(playtime.Count, result.HourlyPlaytime.Count);
 		}
+
+		[Theory]
+		[AutoFakeItEasyData]
+		public void Compose_AssignsAddedGames(
+			[Frozen] IAddedGamesAggregator addedGamesAggregatorFake,
+			List<AddedGame> games,
+			int year,
+			List<Activity> activities,
+			Composer1970 sut)
+		{
+			// Arrange
+			A.CallTo(() => addedGamesAggregatorFake.GetAddedGames(year))
+				.Returns(games);
+
+			// Act
+			var result = sut.Compose(year, activities);
+
+			// Assert
+			Assert.Equal(games.Count, result.AddedGamesCount);
+		}
 	}
 }

--- a/YearInReview/Localization/en_US.xaml
+++ b/YearInReview/Localization/en_US.xaml
@@ -5,6 +5,7 @@
     <sys:String x:Key="LOC_YearInReview_Notification_SetUsername">Please set your username in the Year In Review plugin settings.</sys:String>
     <sys:String x:Key="LOC_YearInReview_PlaytimeCalendar">Total Playtime</sys:String>
     <sys:String x:Key="LOC_YearInReview_PluginName">Year in Review</sys:String>
+    <sys:String x:Key="LOC_YearInReview_Report1970_AddedGamesCountHeader">You've added {0} games throughout the year to your library.</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_HourlyPlaytimeHeader">And here's a breakdown of your play during a day</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_Intro">Here goes the year {0}, {1}!</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_IntroSubtext">In total, you've spent {0} playing. Now let's see what you've played in {1}.</sys:String>
@@ -26,5 +27,4 @@
     <sys:String x:Key="LOC_YearInReview_Settings_Username">Username</sys:String>
     <sys:String x:Key="LOC_YearInReview_Settings_UserSettingsHeader">User</sys:String>
     <sys:String x:Key="LOC_YearInReview_ValidationErrors_Header">Year In Review cannot run because of these issues:</sys:String>
-    <sys:String x:Key="LOC_YearInReview_Report1970_AddedGamesCountHeader">You've added {0} games throughout the year to your library.</sys:String>
 </ResourceDictionary>

--- a/YearInReview/Localization/en_US.xaml
+++ b/YearInReview/Localization/en_US.xaml
@@ -26,4 +26,5 @@
     <sys:String x:Key="LOC_YearInReview_Settings_Username">Username</sys:String>
     <sys:String x:Key="LOC_YearInReview_Settings_UserSettingsHeader">User</sys:String>
     <sys:String x:Key="LOC_YearInReview_ValidationErrors_Header">Year In Review cannot run because of these issues:</sys:String>
+    <sys:String x:Key="LOC_YearInReview_Report1970_AddedGamesCountHeader">You've added {0} games throughout the year to your library.</sys:String>
 </ResourceDictionary>

--- a/YearInReview/Model/Reports/1970/Composer1970.cs
+++ b/YearInReview/Model/Reports/1970/Composer1970.cs
@@ -13,6 +13,7 @@ namespace YearInReview.Model.Reports._1970
 		private readonly IMostPlayedSourcesAggregator _mostPlayedSourcesAggregator;
 		private readonly IPlaytimeCalendarAggregator _playtimeCalendarAggregator;
 		private readonly IHourlyPlaytimeAggregator _hourlyPlaytimeAggregator;
+		private readonly IAddedGamesAggregator _addedGamesAggregator;
 
 		public Composer1970(
 			IMetadataProvider metadataProvider,
@@ -20,7 +21,8 @@ namespace YearInReview.Model.Reports._1970
 			IMostPlayedGamesAggregator mostPlayedGameAggregator,
 			IMostPlayedSourcesAggregator mostPlayedSourcesAggregator,
 			IPlaytimeCalendarAggregator playtimeCalendarAggregator,
-			IHourlyPlaytimeAggregator hourlyPlaytimeAggregator)
+			IHourlyPlaytimeAggregator hourlyPlaytimeAggregator,
+			IAddedGamesAggregator addedGamesAggregator)
 		{
 			_metadataProvider = metadataProvider;
 			_totalPlaytimeAggregator = totalPlaytimeAggregator;
@@ -28,6 +30,7 @@ namespace YearInReview.Model.Reports._1970
 			_mostPlayedSourcesAggregator = mostPlayedSourcesAggregator;
 			_playtimeCalendarAggregator = playtimeCalendarAggregator;
 			_hourlyPlaytimeAggregator = hourlyPlaytimeAggregator;
+			_addedGamesAggregator = addedGamesAggregator;
 		}
 
 		public Report1970 Compose(int year, IReadOnlyCollection<Activity> activities)
@@ -67,7 +70,8 @@ namespace YearInReview.Model.Reports._1970
 				{
 					Hour = x.Key,
 					Playtime = x.Value
-				}).ToList()
+				}).ToList(),
+				AddedGamesCount = _addedGamesAggregator.GetAddedGames(year).Count
 			};
 		}
 	}

--- a/YearInReview/Model/Reports/1970/MVVM/Report1970View.xaml
+++ b/YearInReview/Model/Reports/1970/MVVM/Report1970View.xaml
@@ -153,7 +153,7 @@
                 </ListBox>
             </StackPanel>
             <TextBlock Visibility="{Binding ShowSingleSource, Converter={StaticResource BoolToCollapsedVisibilityConverter}}" Text="{Binding SingleSourceText}" FontSize="25" Margin="10,48,10,10"></TextBlock>
-            <TextBlock Text="{Binding AddGamesCount}" FontSize="25" TextAlignment="Left" Margin="10,48,10,10"></TextBlock>
+            <TextBlock Text="{Binding AddGamesCountText}" FontSize="25" TextAlignment="Left" Margin="10,48,10,10"></TextBlock>
             <TextBlock Text="{DynamicResource LOC_YearInReview_Report1970_PlaytimeCalendarHeader}" FontSize="25" TextAlignment="Left" Margin="10,48,10,10"></TextBlock>
             <userControls:PlaytimeCalendar ItemsSource="{Binding PlaytimeCalendarDays}"/>
             <TextBlock Text="{DynamicResource LOC_YearInReview_Report1970_HourlyPlaytimeHeader}" FontSize="25" TextAlignment="Left" Margin="10,48,10,10"></TextBlock>

--- a/YearInReview/Model/Reports/1970/MVVM/Report1970View.xaml
+++ b/YearInReview/Model/Reports/1970/MVVM/Report1970View.xaml
@@ -153,6 +153,7 @@
                 </ListBox>
             </StackPanel>
             <TextBlock Visibility="{Binding ShowSingleSource, Converter={StaticResource BoolToCollapsedVisibilityConverter}}" Text="{Binding SingleSourceText}" FontSize="25" Margin="10,48,10,10"></TextBlock>
+            <TextBlock Text="{Binding AddGamesCount}" FontSize="25" TextAlignment="Left" Margin="10,48,10,10"></TextBlock>
             <TextBlock Text="{DynamicResource LOC_YearInReview_Report1970_PlaytimeCalendarHeader}" FontSize="25" TextAlignment="Left" Margin="10,48,10,10"></TextBlock>
             <userControls:PlaytimeCalendar ItemsSource="{Binding PlaytimeCalendarDays}"/>
             <TextBlock Text="{DynamicResource LOC_YearInReview_Report1970_HourlyPlaytimeHeader}" FontSize="25" TextAlignment="Left" Margin="10,48,10,10"></TextBlock>

--- a/YearInReview/Model/Reports/1970/MVVM/Report1970ViewModel.cs
+++ b/YearInReview/Model/Reports/1970/MVVM/Report1970ViewModel.cs
@@ -104,7 +104,7 @@ namespace YearInReview.Model.Reports._1970.MVVM
 
 		public string SingleSourceText => string.Format(ResourceProvider.GetString("LOC_YearInReview_Report1970_SingleSourceText"), MostPlayedSources.FirstOrDefault()?.Name);
 		
-		public string AddGamesCount => string.Format(ResourceProvider.GetString("LOC_YearInReview_Report1970_AddedGamesCountHeader"), AddedGamesCount);
+		public string AddGamesCountText => string.Format(ResourceProvider.GetString("LOC_YearInReview_Report1970_AddedGamesCountHeader"), AddedGamesCount);
 	}
 
 	public class FriendPlaytimeLeaderboardViewModel

--- a/YearInReview/Model/Reports/1970/MVVM/Report1970ViewModel.cs
+++ b/YearInReview/Model/Reports/1970/MVVM/Report1970ViewModel.cs
@@ -27,6 +27,8 @@ namespace YearInReview.Model.Reports._1970.MVVM
 				Year);
 
 			MostPlayedGame = report.MostPlayedGames.First();
+			
+			AddedGamesCount = report.AddedGamesCount;
 
 			MostPlayedGames = report.MostPlayedGames
 				.Select((t, i) => new GameViewModel(api, i + 1, t, MaxBarWidth, MostPlayedGame.TimePlayed)).ToList()
@@ -65,6 +67,8 @@ namespace YearInReview.Model.Reports._1970.MVVM
 		public string IntroMessage { get; set; }
 
 		public string IntroMessageSubtext { get; set; }
+		
+		public int AddedGamesCount { get; set; }
 
 		public ReportGameWithTime MostPlayedGame { get; set; }
 
@@ -99,6 +103,8 @@ namespace YearInReview.Model.Reports._1970.MVVM
 		public string TopSourcesHeader => string.Format(ResourceProvider.GetString("LOC_YearInReview_Report1970_TopSourcesHeader"));
 
 		public string SingleSourceText => string.Format(ResourceProvider.GetString("LOC_YearInReview_Report1970_SingleSourceText"), MostPlayedSources.FirstOrDefault()?.Name);
+		
+		public string AddGamesCount => string.Format(ResourceProvider.GetString("LOC_YearInReview_Report1970_AddedGamesCountHeader"), AddedGamesCount);
 	}
 
 	public class FriendPlaytimeLeaderboardViewModel

--- a/YearInReview/Model/Reports/1970/Report1970.cs
+++ b/YearInReview/Model/Reports/1970/Report1970.cs
@@ -16,5 +16,7 @@ namespace YearInReview.Model.Reports._1970
 		public IReadOnlyList<ReportCalendarDay> PlaytimeCalendarDays { get; set; }
 
 		public IReadOnlyList<ReportHourlyPlaytime> HourlyPlaytime { get; set; }
+		
+		public int AddedGamesCount { get; set; }
 	}
 }

--- a/YearInReview/YearInReview.cs
+++ b/YearInReview/YearInReview.cs
@@ -170,13 +170,15 @@ namespace YearInReview
 			var totalPlaytimeAggregator = new TotalPlaytimeAggregator();
 			var playtimeCalendarAggregator = new PlaytimeCalendarAggregator(Api);
 			var hourlyPlaytimeAggregator = new HourlyPlaytimeAggregator();
+			var addedGamesAggregator = new AddedGamesAggregator(Api);
 			var composer = new Composer1970(
 				metadataProvider,
 				totalPlaytimeAggregator,
 				mostPlayedGamesAggregator,
 				mostPlayedSourcesAggregator,
 				playtimeCalendarAggregator,
-				hourlyPlaytimeAggregator);
+				hourlyPlaytimeAggregator,
+				addedGamesAggregator);
 			var gameActivityExtension = new GameActivityExtension(Api.Paths.ExtensionsDataPath);
 			var specificYearActivityFilter = new SpecificYearActivityFilter();
 			var reportPersistence = new ReportPersistence(GetPluginUserDataPath());


### PR DESCRIPTION
Implements added games count in report and displays the number in report view according to #3.

Since you mentioned in issue #3 that "We only care about the count of added games for now," I added only the `AddedGamesCount` as an `int` value to `YearInReview/Model/Reports/1970/Report1970.cs`.
With this structure, we lose information about the specific games added during the year. If we want to display more detailed data about the added games, we can modify the report to include a list of the added games.