### PR TITLE
most played game ux improvements

### DIFF
--- a/YearInReview/Infrastructure/Services/ReadableTimeFormatter.cs
+++ b/YearInReview/Infrastructure/Services/ReadableTimeFormatter.cs
@@ -6,7 +6,10 @@ namespace YearInReview.Infrastructure.Services
 {
 	public class ReadableTimeFormatter
 	{
-		public static string FormatTime(int seconds)
+		private const string NonBreakableSpace = "\u00A0";
+		private const string BreakableSpace = " ";
+		
+		public static string FormatTime(int seconds, bool nonLineBreaking = false)
 		{
 			if (seconds < 60)
 			{
@@ -19,18 +22,24 @@ namespace YearInReview.Infrastructure.Services
 			if (timeSpan.Days > 0)
 			{
 				readableText.Append(string.Format(ResourceProvider.GetString("LOC_YearInReview_ReadableTime_DayPart"), timeSpan.Days));
-				readableText.Append(" ");
+				readableText.Append(BreakableSpace);
 			}
 			if (timeSpan.Hours > 0)
 			{
 				readableText.Append(string.Format(ResourceProvider.GetString("LOC_YearInReview_ReadableTime_HourPart"), timeSpan.Hours));
-				readableText.Append(" ");
+				readableText.Append(BreakableSpace);
 			}
 			if (timeSpan.Minutes > 0)
 			{
 				readableText.Append(string.Format(ResourceProvider.GetString("LOC_YearInReview_ReadableTime_MinutePart"), timeSpan.Minutes));
 			}
 
+			// Replace breakable spaces with non-breakable spaces, if nonLineBreaking is set
+			if (nonLineBreaking)
+			{
+				readableText.Replace(BreakableSpace, NonBreakableSpace);
+			}
+			
 			return readableText.ToString().Trim();
 		}
 	}

--- a/YearInReview/Infrastructure/UserControls/PlaytimeCalendar.xaml.cs
+++ b/YearInReview/Infrastructure/UserControls/PlaytimeCalendar.xaml.cs
@@ -135,7 +135,7 @@ namespace YearInReview.Infrastructure.UserControls
 			var mostPlayedText = string.Format(
 				ResourceProvider.GetString("LOC_YearInReview_Report1970_PlaytimeCalendarMostPlayedGame"), 
 				mostPlayed.Game.Name,
-				ReadableTimeFormatter.FormatTime(mostPlayed.TotalTimePlayed)
+				ReadableTimeFormatter.FormatTime(mostPlayed.TotalTimePlayed, true)
 				);
 			
 			// add the most played game text to the grid

--- a/YearInReview/Localization/en_US.xaml
+++ b/YearInReview/Localization/en_US.xaml
@@ -12,7 +12,7 @@
     <sys:String x:Key="LOC_YearInReview_Report1970_FriendsLeaderboardHeader">Let's see how you rank amongst your friends regarding playtime</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_MostPlayedGameMessage">It looks like you could not get enough of {0}. You've spent {1} playing it.</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_PlaytimeCalendarHeader">Here's how your playtime looked over the year</sys:String>
-    <sys:String x:Key="LOC_YearInReview_Report1970_PlaytimeCalendarMostPlayedGame">Most played game: {0} ({1})</sys:String>
+    <sys:String x:Key="LOC_YearInReview_Report1970_PlaytimeCalendarMostPlayedGame">Mostly: {0} ({1})</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_SingleSourceText">This year is all about {0}. You haven't played on any other libraries.</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_TopGamesHeader">And here's a look at your overall top {0}</sys:String>
     <sys:String x:Key="LOC_YearInReview_Report1970_TopSourcesHeader">Let's see which library was your favourite this year</sys:String>


### PR DESCRIPTION
Implemented suggested UX improvements according to #17.
The most played game of every month in the calendar view will be displayed with a shorter explanation string. Additionally, the formatted playtime is changed to prevent line breaks.